### PR TITLE
Update bgp/parser.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All metrics are enabled by default. To disable something pass a flag `--<name>.e
 
 Name     | Description | OS
 ---------|-------------|----
-bgp | BGP (message count, prefix counts per peer, session state) | IOS XE
+bgp | BGP (message count, prefix counts per peer, session state) | IOS XE/NX-OS
 environment | Environment (temperatures, state of power supply) | NX-OS/IOS XE/IOS
 facts | System informations (OS Version, memory: total/used/free, cpu: 5s/1m/5m/interrupts) | IOS XE/IOS
 interface | Interfaces (transmitted/received: bytes/errors/drops, admin/oper state) | NX-OS (*_drops is always 0)/IOS XE/IOS

--- a/bgp/parser.go
+++ b/bgp/parser.go
@@ -10,7 +10,7 @@ import (
 
 // Parse parses cli output and tries to find bgp sessions with related data
 func (c *bgpCollector) Parse(ostype string, output string) ([]BgpSession, error) {
-	if ostype != rpc.IOSXE {
+	if ostype != rpc.IOSXE && ostype != rpc.NXOS {
 		return nil, errors.New("'show bgp all summary' is not implemented for " + ostype)
 	}
 	items := []BgpSession{}


### PR DESCRIPTION
Enable BGP metric check for NX-OS.

Tested with Nexus 5672up with 7.3(3)N1(1).

#1 