### PR TITLE
Make timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ web.telemetry-path | Path under which to expose metrics. | /metrics
 ssh.targets | Comma seperated list of hosts to scrape |
 ssh.user | Username to use for SSH connection | cisco_exporter
 ssh.keyfile | Key file to use for SSH connection | cisco_exporter
+ssh.timeout | Timeout in seconds to use for SSH connection | 5
 debug | Show verbose debug output | false
 legacy.ciphers | Allow insecure legacy ciphers: aes128-cbc 3des-cbc aes192-cbc aes256-cbc | false
 

--- a/cisco_collector.go
+++ b/cisco_collector.go
@@ -33,12 +33,11 @@ func init() {
 type ciscoCollector struct {
 	targets    []string
 	collectors map[string]collector.RPCCollector
-	timeout    int
 }
 
-func newCiscoCollector(targets []string, timeout int) *ciscoCollector {
+func newCiscoCollector(targets []string) *ciscoCollector {
 	collectors := collectors()
-	return &ciscoCollector{targets, collectors, timeout}
+	return &ciscoCollector{targets, collectors}
 }
 
 func collectors() map[string]collector.RPCCollector {
@@ -100,7 +99,7 @@ func (c *ciscoCollector) collectForHost(host string, ch chan<- prometheus.Metric
 		ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(t).Seconds(), l...)
 	}()
 
-	conn, err := connector.NewSSSHConnection(host, *sshUsername, *sshKeyFile, *legacyCiphers, c.timeout)
+	conn, err := connector.NewSSSHConnection(host, *sshUsername, *sshKeyFile, *legacyCiphers, *sshTimeout)
 	if err != nil {
 		log.Errorln(err)
 		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 0, l...)

--- a/cisco_collector.go
+++ b/cisco_collector.go
@@ -33,11 +33,12 @@ func init() {
 type ciscoCollector struct {
 	targets    []string
 	collectors map[string]collector.RPCCollector
+	timeout    int
 }
 
-func newCiscoCollector(targets []string) *ciscoCollector {
+func newCiscoCollector(targets []string, timeout int) *ciscoCollector {
 	collectors := collectors()
-	return &ciscoCollector{targets, collectors}
+	return &ciscoCollector{targets, collectors, timeout}
 }
 
 func collectors() map[string]collector.RPCCollector {
@@ -99,7 +100,7 @@ func (c *ciscoCollector) collectForHost(host string, ch chan<- prometheus.Metric
 		ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(t).Seconds(), l...)
 	}()
 
-	conn, err := connector.NewSSSHConnection(host, *sshUsername, *sshKeyFile, *legacyCiphers)
+	conn, err := connector.NewSSSHConnection(host, *sshUsername, *sshKeyFile, *legacyCiphers, c.timeout)
 	if err != nil {
 		log.Errorln(err)
 		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 0, l...)

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func handleMetricsRequest(w http.ResponseWriter, r *http.Request) {
 	reg := prometheus.NewRegistry()
 
 	targets := strings.Split(*sshHosts, ",")
-	c := newCiscoCollector(targets, *sshTimeout)
+	c := newCiscoCollector(targets)
 	reg.MustRegister(c)
 
 	promhttp.HandlerFor(reg, promhttp.HandlerOpts{

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	sshHosts          = flag.String("ssh.targets", "", "SSH Hosts to scrape")
 	sshUsername       = flag.String("ssh.user", "cisco_exporter", "Username to use for SSH connection")
 	sshKeyFile        = flag.String("ssh.keyfile", "", "Key file to use for SSH connection")
+	sshTimeout        = flag.Int("ssh.timeout", 5, "Timeout to use for SSH connection")
 	debug             = flag.Bool("debug", false, "Show verbose debug output in log")
 	legacyCiphers     = flag.Bool("legacy.ciphers", false, "Allow legacy CBC ciphers")
 	bgpEnabled        = flag.Bool("bgp.enabled", true, "Scrape bgp metrics")
@@ -79,7 +80,7 @@ func handleMetricsRequest(w http.ResponseWriter, r *http.Request) {
 	reg := prometheus.NewRegistry()
 
 	targets := strings.Split(*sshHosts, ",")
-	c := newCiscoCollector(targets)
+	c := newCiscoCollector(targets, *sshTimeout)
 	reg.MustRegister(c)
 
 	promhttp.HandlerFor(reg, promhttp.HandlerOpts{


### PR DESCRIPTION
This PR fixes #3 by introducing the optional config flag `--ssh.timeout`(defaulting to 5), which is the SSH connection timeout in seconds. It thus supersedes the `timeoutInSeconds` global variable.

If there’s anything that we still need to make this mergeable, let me know!

Cheers