### PR TITLE
Make batch size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ssh.targets | Comma seperated list of hosts to scrape |
 ssh.user | Username to use for SSH connection | cisco_exporter
 ssh.keyfile | Key file to use for SSH connection | cisco_exporter
 ssh.timeout | Timeout in seconds to use for SSH connection | 5
+ssh.batch-size | The SSH response batch size | 10000
 debug | Show verbose debug output | false
 legacy.ciphers | Allow insecure legacy ciphers: aes128-cbc 3des-cbc aes192-cbc aes256-cbc | false
 

--- a/cisco_collector.go
+++ b/cisco_collector.go
@@ -99,7 +99,7 @@ func (c *ciscoCollector) collectForHost(host string, ch chan<- prometheus.Metric
 		ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(t).Seconds(), l...)
 	}()
 
-	conn, err := connector.NewSSSHConnection(host, *sshUsername, *sshKeyFile, *legacyCiphers, *sshTimeout)
+	conn, err := connector.NewSSSHConnection(host, *sshUsername, *sshKeyFile, *legacyCiphers, *sshTimeout, *sshBatchSize)
 	if err != nil {
 		log.Errorln(err)
 		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 0, l...)

--- a/connector/connection.go
+++ b/connector/connection.go
@@ -48,7 +48,7 @@ func config(user, keyFile string, legacyCiphers bool, timeout int) (*ssh.ClientC
 }
 
 // NewSSSHConnection connects to device
-func NewSSSHConnection(host, user, keyFile string, legacyCiphers bool, timeout int) (*SSHConnection, error) {
+func NewSSSHConnection(host, user, keyFile string, legacyCiphers bool, timeout int, batchSize int) (*SSHConnection, error) {
 	if !strings.Contains(host, ":") {
 		host = host + ":22"
 	}
@@ -56,6 +56,7 @@ func NewSSSHConnection(host, user, keyFile string, legacyCiphers bool, timeout i
 	c := &SSHConnection{
 		Host:          host,
 		legacyCiphers: legacyCiphers,
+		batchSize:     batchSize,
 	}
 	err := c.Connect(user, keyFile, timeout)
 	if err != nil {
@@ -73,6 +74,7 @@ type SSHConnection struct {
 	stdout        io.Reader
 	session       *ssh.Session
 	legacyCiphers bool
+	batchSize     int
 }
 
 // Connect connects to the device
@@ -158,7 +160,7 @@ func loadPublicKeyFile(file string) (ssh.AuthMethod, error) {
 
 func (c *SSHConnection) readln(ch chan result, cmd string, r io.Reader) {
 	re := regexp.MustCompile(`.+#\s?$`)
-	buf := make([]byte, 10000)
+	buf := make([]byte, c.batchSize)
 	loadStr := ""
 	for {
 		n, err := r.Read(buf)

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	sshUsername       = flag.String("ssh.user", "cisco_exporter", "Username to use for SSH connection")
 	sshKeyFile        = flag.String("ssh.keyfile", "", "Key file to use for SSH connection")
 	sshTimeout        = flag.Int("ssh.timeout", 5, "Timeout to use for SSH connection")
+	sshBatchSize      = flag.Int("ssh.batch-size", 10000, "The SSH response batch size")
 	debug             = flag.Bool("debug", false, "Show verbose debug output in log")
 	legacyCiphers     = flag.Bool("legacy.ciphers", false, "Allow legacy CBC ciphers")
 	bgpEnabled        = flag.Bool("bgp.enabled", true, "Scrape bgp metrics")


### PR DESCRIPTION
This PR fixes #5 by making batch sizes configurable. It’s extremely similar to the fix in #4, using the same path to get the option down to the connection handler.

It’s also completely backwards-compatible (like #4), because the default is the hardcoded value from before!

Cheers