### PR TITLE
connector: remove unreachable code

### DIFF
--- a/connector/connection.go
+++ b/connector/connection.go
@@ -130,8 +130,6 @@ func (c *SSHConnection) RunCommand(cmd string) (string, error) {
 	case <-time.After(cachedConfig.Timeout):
 		return "", errors.New("Timeout reached")
 	}
-
-	return "", errors.New("Something went wrong")
 }
 
 // Close closes connection


### PR DESCRIPTION
This PR removes unreachable code inside `connection.go`. The `select` statement will always return something, and thus we don’t need to add the catch-all clause at the end.

This was detected by [`go vet`](https://golang.org/cmd/vet/).

Cheers