### PR TITLE
support host_pattern in config devices list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ devices:
   - host: host2.example.com:2233
     username: exporter
     password: secret
+  - host: router.*.example.com
+    # Tell the exporter that this hostname should be used as a pattern when loading
+    # device-specific configurations. This example would match against a hostname
+    # like "router1.example.com".
+    host_pattern: true
+    username: exporter
+    password: secret
+
 
 features:
   bgp: true

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io"
 	"io/ioutil"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -31,6 +32,8 @@ type DeviceConfig struct {
 	Timeout       *int           `yaml:"timeout,omitempty"`
 	BatchSize     *int           `yaml:"batch_size,omitempty"`
 	Features      *FeatureConfig `yaml:"features,omitempty"`
+	IsHostPattern bool           `yaml:"host_pattern,omitempty"`
+	HostPattern   *regexp.Regexp
 }
 
 // FeatureConfig is the list of collectors enabled or disabled
@@ -66,6 +69,13 @@ func Load(reader io.Reader) (*Config, error) {
 	}
 
 	for _, d := range c.Devices {
+		if d.IsHostPattern {
+			hostPattern, err := regexp.Compile(d.Host)
+			if err != nil {
+				return nil, err
+			}
+			d.HostPattern = hostPattern
+		}
 		if d.Features == nil {
 			continue
 		}


### PR DESCRIPTION
Adds ability to specify `host_pattern: True` in configuration file under `devices`. In that case the `host` value is treated as a regex. 

That allows you to not have to specify every target in exporter configuration, but to have prometheus server scrape dynamically  added or removed hosts.

When scraping metrics if no target query parameter is given in URL, any device that has `host_pattern: True` is skipped. However if target is supplied, and it doesn't match any host values exactly, then host_pattern entries are compared.

The code is mostly the same as in https://github.com/czerwonk/junos_exporter