### PR TITLE
Enable CPU metrics + adjust power/temperature regexes for NX-OS

### DIFF
--- a/facts/parser.go
+++ b/facts/parser.go
@@ -57,7 +57,7 @@ func (c *factsCollector) ParseMemory(ostype string, output string) ([]MemoryFact
 
 // ParseCPU parses cli output and tries to find current CPU utilization
 func (c *factsCollector) ParseCPU(ostype string, output string) (CPUFact, error) {
-	if ostype != rpc.IOSXE && ostype != rpc.IOS {
+	if ostype != rpc.IOSXE && ostype != rpc.NXOS && ostype != rpc.IOS {
 		return CPUFact{}, errors.New("'show process cpu' is not implemented for " + ostype)
 	}
 	memoryRegexp, _ := regexp.Compile(`^\s*CPU utilization for five seconds: (\d+)%\/(\d+)%; one minute: (\d+)%; five minutes: (\d+)%.*$`)


### PR DESCRIPTION
- Enable CPU metrics for NX-OS since `show processes cpu` appears to work, at least on NX-OS 9.3(5)
- Change `tempRegexp[rpc.NXOS]` to support variable digit temperature values instead of hardcoding some temperature matches to 2 digits
- Add new power regex for NX-OS devices that matches the test output [1]
    
Tested on NX-OS 9.3(5).
    
[1]:
```
Power Supply:
Voltage: 12 Volts
Power                      Actual             Actual        Total
Supply    Model            Output             Input        Capacity     Status
                           (Watts )           (Watts )     (Watts )
-------  ----------  ---------------  ------  ----------  --------------------
1        N2200-PAC-400W-B       48 W               53 W       400 W      Ok
2        N2200-PAC-400W-B       53 W               60 W       400 W      Ok
```