### PR TITLE
New metrics: mac address table counters per vlan

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ environment | Environment (temperatures, state of power supply) | NX-OS/IOS XE/I
 facts | System informations (OS Version, memory: total/used/free, cpu: 5s/1m/5m/interrupts) | IOS XE/IOS
 interfaces | Interfaces (transmitted/received: bytes/errors/drops, admin/oper state) | NX-OS (*_drops is always 0)/IOS XE/IOS
 optics | Optical signals (tx/rx) | NX-OS/IOS XE/IOS
+mactable | MAC address table (count of MAC addresses per VLAN) | NX-OS
 
 ## Install
 ```bash
@@ -76,6 +77,7 @@ features:
   facts: true
   interfaces: true
   optics: true
+  mactable: true
 
 ```
 

--- a/collectors.go
+++ b/collectors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lwlcom/cisco_exporter/facts"
 	"github.com/lwlcom/cisco_exporter/interfaces"
 	"github.com/lwlcom/cisco_exporter/optics"
+	"github.com/lwlcom/cisco_exporter/mactable"
 )
 
 type collectors struct {
@@ -40,7 +41,7 @@ func (c *collectors) initCollectorsForDevice(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "facts", f.Facts, facts.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "interfaces", f.Interfaces, interfaces.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "optics", f.Optics, optics.NewCollector)
-
+	c.addCollectorIfEnabledForDevice(device, "mactable", f.Mactable, mactable.NewCollector)
 }
 
 func (c *collectors) addCollectorIfEnabledForDevice(device *connector.Device, key string, enabled *bool, newCollector func() collector.RPCCollector) {

--- a/config.yml.example
+++ b/config.yml.example
@@ -25,3 +25,5 @@ features:
   facts: true
   interfaces: true
   optics: true
+  mactable: true
+

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ type FeatureConfig struct {
 	Facts       *bool `yaml:"facts,omitempty"`
 	Interfaces  *bool `yaml:"interfaces,omitempty"`
 	Optics      *bool `yaml:"optics,omitempty"`
+	Mactable    *bool `yaml:"mactable,omitempty"`
 }
 
 // New creates a new config
@@ -84,6 +85,9 @@ func Load(reader io.Reader) (*Config, error) {
 		if d.Features.Optics == nil {
 			d.Features.Optics = c.Features.Optics
 		}
+		if d.Features.Mactable == nil {
+			d.Features.Mactable = c.Features.Mactable
+		}
 	}
 
 	return c, nil
@@ -106,6 +110,8 @@ func (c *Config) setDefaultValues() {
 	f.Interfaces = &interfaces
 	optics := true
 	f.Optics = &optics
+	mactable := true
+	f.Mactable = &mactable
 }
 
 // DevicesFromTargets creates devices configs from targets list

--- a/mactable/mactable.go
+++ b/mactable/mactable.go
@@ -1,0 +1,17 @@
+package mactable
+
+type Interface struct {
+	VLAN        string
+	Count         float64
+}
+
+type Mactableentry struct {
+	VLAN        int
+	MAC         string
+	Type        string
+	Age         string
+	Secure      string
+	NTFY        string
+	Port        string
+	Count       int
+}

--- a/mactable/mactable_collector.go
+++ b/mactable/mactable_collector.go
@@ -1,0 +1,75 @@
+package mactable
+
+import (
+	"strconv"
+
+	"github.com/lwlcom/cisco_exporter/rpc"
+
+	"github.com/lwlcom/cisco_exporter/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "cisco_mactable_"
+
+var (
+	countDesc       *prometheus.Desc
+	VLANDesc      *prometheus.Desc
+)
+
+func init() {
+	l := []string{"target", "vlan"}
+	countDesc = prometheus.NewDesc(prefix+"count", "Count of MAC addresses", l, nil)
+}
+
+type mactableCollector struct {
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &mactableCollector{}
+}
+
+// Name returns the name of the collector
+func (*mactableCollector) Name() string {
+	return "Mactable"
+}
+
+// Describe describes the metrics
+func (*mactableCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- countDesc
+}
+
+// Collect collects metrics from Cisco
+func (c *mactableCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	out, err := client.RunCommand("show vlan brief | include active | no-more")
+	if err != nil {
+		return err
+	}
+	vlans, err := c.ParseVlans(client.OSType, out)
+	if err != nil {
+		return err
+	}
+
+    items := make([]Mactableentry, 0)
+	for _, vlan := range vlans {
+		out, err := client.RunCommand("show mac address-table count dynamic vlan " + strconv.Itoa(vlan))
+		if err != nil {
+			return err
+		}
+		count, err := c.Parse(client.OSType, out)
+		if err != nil {
+			return err
+		}
+		items = append(items, Mactableentry{
+			VLAN: vlan,
+			Count: count,
+		})
+	}
+
+	for _, item := range items {
+		l := append(labelValues, strconv.Itoa(item.VLAN))
+		ch <- prometheus.MustNewConstMetric(countDesc, prometheus.GaugeValue, float64(item.Count), l...)
+	}
+
+	return nil
+}

--- a/mactable/parser.go
+++ b/mactable/parser.go
@@ -1,0 +1,50 @@
+package mactable
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/lwlcom/cisco_exporter/rpc"
+)
+
+func (c *mactableCollector) Parse(ostype string, output string) (int, error) {
+	if ostype != rpc.NXOS {
+		return 0, errors.New("mactable is not implemented yet for " + ostype)
+	}
+
+	macRegexp := regexp.MustCompile(`in Use:\s+(\d+)$`)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if matches := macRegexp.FindStringSubmatch(line); matches != nil {
+			count, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return 0, err
+			}
+			return count, nil
+		}
+	}
+
+	return 0, errors.New("count not found")
+}
+
+func (c *mactableCollector) ParseVlans(ostype string, output string) ([]int, error) {
+	if ostype != rpc.NXOS {
+		return nil, errors.New("mactable is not implemented yet for " + ostype)
+	}
+	
+	vlans := make([]int, 0)
+	vlanRegexp := regexp.MustCompile(`^\s*(\d+)\s+`)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if matches := vlanRegexp.FindStringSubmatch(line); matches != nil {
+			vlan, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return nil, err
+			}
+			vlans = append(vlans, vlan)
+		}
+	}
+	return vlans, nil
+}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	factsEnabled       = flag.Bool("facts.enabled", true, "Scrape system metrics")
 	interfacesEnabled  = flag.Bool("interfaces.enabled", true, "Scrape interface metrics")
 	opticsEnabled      = flag.Bool("optics.enabled", true, "Scrape optic metrics")
+	mactableEnabled    = flag.Bool("mactable.enabled", true, "Scrape mactable metrics")
 	configFile         = flag.String("config.file", "", "Path to config file")
 	devices            []*connector.Device
 	cfg                *config.Config
@@ -113,6 +114,7 @@ func loadConfigFromFlags() *config.Config {
 	f.Facts = factsEnabled
 	f.Interfaces = interfacesEnabled
 	f.Optics = opticsEnabled
+	f.Mactable = mactableEnabled
 
 	return c
 }


### PR DESCRIPTION
In ISPs, expecially users facing switches, it is important to monitor number of macs per VLAN. Sometimes due misconfiguration, sometimes malicious intent, and just due growth it is easy to miss moment when switch will exceed internal resources.

This patch tested on NXOS: version 9.3(10), Nexus3064 Example snippet:
<pre>
cisco_mactable_count{target="10.250.25.2",vlan="2015"} 86 
cisco_mactable_count{target="10.250.25.2",vlan="2016"} 91 
cisco_mactable_count{target="10.250.25.2",vlan="2018"} 160 
cisco_mactable_count{target="10.250.25.2",vlan="2019"} 330
</pre>